### PR TITLE
Potential fix for code scanning alert no. 2: Reflected server-side cross-site scripting

### DIFF
--- a/app/to_start_date.py
+++ b/app/to_start_date.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from flask import Blueprint, abort, current_app, jsonify, request
+from flask import Blueprint, abort, current_app, jsonify, request, escape
 
 from app.util import get_current_url
 
@@ -77,7 +77,7 @@ def delete_to_start_date_from_questionnaire(questionnaire):
         abort(404, description=f"No data found for {questionnaire}")
     current_app.datastore.delete_to_start_date(questionnaire)
     current_app.logger.info(f"{questionnaire} deleted")
-    return f"Deleted {questionnaire}", 204
+    return f"Deleted {escape(questionnaire)}", 204
 
 
 def get_formatted_date(request_body):


### PR DESCRIPTION
Potential fix for [https://github.com/ONSdigital/blaise-instrument-metadata-service/security/code-scanning/2](https://github.com/ONSdigital/blaise-instrument-metadata-service/security/code-scanning/2)

The recommended fix is to escape the `questionnaire` variable before it is included in any response body that is sent to the client. Since the code is written using Flask, the built-in `flask.escape` should be used to prevent the possibility of XSS. It is necessary to import `escape` from `flask` at the top of the file if it is not already imported. The usage is straightforward: replace `{questionnaire}` with `{escape(questionnaire)}` in the offending line.  
**Modify**:
- Import `escape` from `flask` (edit the import statement at the top).
- Wrap the `questionnaire` variable with `escape()` in the return on line 80.

No changes to existing functionality for genuine input, but user input will now be safely escaped before being outputted to the client.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
