### PR TITLE
Potential fix for code scanning alert no. 1: Reflected server-side cross-site scripting

### DIFF
--- a/app/tm_release_date.py
+++ b/app/tm_release_date.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from flask import Blueprint, abort, current_app, jsonify, request
+from flask import Blueprint, abort, current_app, jsonify, request, escape
 
 from app.util import get_current_url
 
@@ -74,7 +74,7 @@ def delete_tm_release_date_from_questionnaire(questionnaire):
         abort(404, description=f"No data found for {questionnaire}")
     current_app.datastore.delete_tm_release_date(questionnaire)
     current_app.logger.info(f"{questionnaire} deleted")
-    return f"Deleted {questionnaire}", 204
+    return f"Deleted {escape(questionnaire)}", 204
 
 
 def get_formatted_date(request_body):


### PR DESCRIPTION
Potential fix for [https://github.com/ONSdigital/blaise-instrument-metadata-service/security/code-scanning/1](https://github.com/ONSdigital/blaise-instrument-metadata-service/security/code-scanning/1)

To fix this vulnerability, the code should escape any user-originating input before reflecting it in an HTTP response. In Flask, the `flask.escape()` utility should be used to sanitize potentially unsafe content by escaping HTML special characters. Specifically, the return statement on line 77 should escape `questionnaire` before including it in the output string. Additionally, as a best practice for Flask APIs, a 204 response should have *no* response body—if that can be done without breaking clients, it's even safer to simply return an empty string/body. If a message is required, ensure it's escaped before being returned, and ideally also return as application/json or set the response content type to 'text/plain'. The necessary edit is to import `escape` from `flask` (if not already imported), and to wrap the `questionnaire` value in `escape()` at the response construction point.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
